### PR TITLE
Revert arm change

### DIFF
--- a/.github/workflows/call-build-image.yml
+++ b/.github/workflows/call-build-image.yml
@@ -14,6 +14,6 @@ jobs:
       app_name: "simplelogin"
       release_type: "github"
       release_url: "https://api.github.com/repos/simple-login/app"
-      target-arch: "64"
+      target-arch: "amd64"
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The architectures supported by this image are:
 | Architecture | Available | Tag |
 | :----: | :----: | ---- |
 | x86-64 | ✅ | latest |
-| arm64 | ✅ | latest |
+| arm64 | ❌ | latest |
 
 ## Application Setup
 


### PR DESCRIPTION
There seems to be an issue with `uv` that causes the compilation of `pyre2` to fail on arm64.
https://github.com/astral-sh/uv/issues/6812