### PR TITLE
Fix arm again

### DIFF
--- a/.github/workflows/call-build-image.yml
+++ b/.github/workflows/call-build-image.yml
@@ -14,6 +14,6 @@ jobs:
       app_name: "simplelogin"
       release_type: "github"
       release_url: "https://api.github.com/repos/simple-login/app"
-      target-arch: "amd64"
+      target-arch: "64"
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH="$HOME/.local/bin:/code/.venv/bin:$PATH"
 RUN \
   echo "**** install build packages ****" && \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     gcc \
     git \
     libre2-dev \
@@ -57,7 +57,11 @@ RUN \
   curl -o /tmp/uv-installer.sh -L https://astral.sh/uv/install.sh && \
   sh /tmp/uv-installer.sh && \
   uv python install `cat .python-version` && \
-  uv sync --locked && \
+  case "$(uname -m)" in \
+    'x86_64') export ARGS='' ;; \
+    'aarch64') export ARGS='--no-install-package pyre2 --no-install-package pycryptodome' ;; \
+  esac && \
+  uv sync --no-dev --locked $ARGS && \
   echo "**** install runtime packages ****" && \
   apt-get install -y \
     gnupg \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The architectures supported by this image are:
 | Architecture | Available | Tag |
 | :----: | :----: | ---- |
 | x86-64 | ✅ | latest |
-| arm64 | ❌ | latest |
+| arm64 | ✅ | latest |
 
 ## Application Setup
 


### PR DESCRIPTION
Build arm64 without `pyre2` and `pycryptodome` which are used by paddle payment due to compilation errors, should be fine for self-hosting.